### PR TITLE
Add support for Particle devices (www.particle.io)

### DIFF
--- a/NexSerialConfig.h
+++ b/NexSerialConfig.h
@@ -20,6 +20,12 @@
 #define dbSerial Serial
 
 /*Define Nextion serial*/
-#define nexSerial Serial2
+
+// To also support the growing community of Particle devices (www.particle.io)
+#if defined(SPARK) || defined(PLATFORM_ID)
+  #define nexSerial Serial1
+#elif
+  #define nexSerial Serial2
+#endif
 
 #endif 

--- a/NexSerialConfig.h
+++ b/NexSerialConfig.h
@@ -23,7 +23,8 @@
 
 // To also support the growing community of Particle devices (www.particle.io)
 #if defined(SPARK) || defined(PLATFORM_ID)
-  #define nexSerial Serial1
+  #define nexSerial Serial1  // RX/TX pins
+  //#define nexSerial Serial2  // D0/D1 pins on Core (on Photon not easily usable)
 #elif
   #define nexSerial Serial2
 #endif

--- a/NexTouch.h
+++ b/NexTouch.h
@@ -16,7 +16,16 @@
 #ifndef __NEXTOUCH_H__
 #define __NEXTOUCH_H__
 #ifdef __cplusplus
-#include <Arduino.h>
+
+// To also support the growing community of Particle devices (www.particle.io)
+#if defined(SPARK) || defined(PLATFORM_ID)
+  #include "application.h"
+
+  extern char* itoa(int a, char* buffer, unsigned char radix);
+#else // not a Particle device
+  #include <Arduino.h>
+#endif  // Arduino
+
 #include "NexSerialConfig.h"
 
 typedef uint8_t NexPid;


### PR DESCRIPTION
Particle offers onboard WiFi (Spark/Particle Core and Particle Photon) and 2G/3G (Particle Electron soon to come) with a certain degree of Arduino compatibility.

I just love these devices and want to see them supported by this lib out the box.