### PR TITLE
Update for SAMD MCU

### DIFF
--- a/NexUpload.cpp
+++ b/NexUpload.cpp
@@ -14,10 +14,11 @@
  */
 
 #include "NexUpload.h"
-#include <SoftwareSerial.h>
 
 //#define USE_SOFTWARE_SERIAL
+
 #ifdef USE_SOFTWARE_SERIAL
+#include <SoftwareSerial.h>
 SoftwareSerial dbSerial(3, 2); /* RX:D3, TX:D2 */
 #define DEBUG_SERIAL_ENABLE
 #endif


### PR DESCRIPTION
It serves to make the library compatible with SAMD MCU (Arduino Zero, samd21) and all MCUs incompatible with SoftwareSerial.