### PR TITLE
new String member in object to store the name

### DIFF
--- a/NexObject.cpp
+++ b/NexObject.cpp
@@ -18,7 +18,8 @@ NexObject::NexObject(uint8_t pid, uint8_t cid, const char *name)
 {
     this->__pid = pid;
     this->__cid = cid;
-    this->__name = name;
+    this->__name_str = name;
+    this->__name = __name_str.c_str();
 }
 
 uint8_t NexObject::getObjPid(void)

--- a/NexObject.h
+++ b/NexObject.h
@@ -76,6 +76,7 @@ private: /* data */
     uint8_t __pid; /* Page ID */
     uint8_t __cid; /* Component ID */
     const char *__name; /* An unique name */
+    String __name_str; /* space to store the name */
 };
 /**
  * @}


### PR DESCRIPTION
We need to store the name anyway and I think it is best if the object itselfe provides a space to store the name. 
The change links the old member (const char *) to the new member. So there is no need to make further changes.